### PR TITLE
Fix binary grammar definition of the branch hints custom section

### DIFF
--- a/document/core/appendix/custom.rst
+++ b/document/core/appendix/custom.rst
@@ -184,6 +184,8 @@ Value  Meaning
 
 .. math::
    \begin{array}{llclll}
+   \production{branch hints section} & \Bbranchhintssec &::=&
+     \Bsection_0(\Bfuncbranchhints) \\
    \production{function branch hints} & \Bfuncbranchhints &::=&
      \Bfuncidx~\hex{00}~\Bvec(\Bbranchhint) \\
    \production{branch hint} & \Bbranchhint &::=&

--- a/document/core/appendix/custom.rst
+++ b/document/core/appendix/custom.rst
@@ -185,7 +185,7 @@ Value  Meaning
 .. math::
    \begin{array}{llclll}
    \production{branch hints section} & \Bbranchhintssec &::=&
-     \Bsection_0(\Bfuncbranchhints) \\
+     \Bsection_0(\Bvec(\Bfuncbranchhints)) \\
    \production{function branch hints} & \Bfuncbranchhints &::=&
      \Bfuncidx~\hex{00}~\Bvec(\Bbranchhint) \\
    \production{branch hint} & \Bbranchhint &::=&

--- a/document/core/util/macros.def
+++ b/document/core/util/macros.def
@@ -1050,6 +1050,7 @@
 
 .. Branch Hints Section, non-terminals
 
+.. |Bbranchhintssec| mathdef:: \xref{appendix/custom}{binary-branchhintssec}{\B{branchhintssec}}
 .. |Bfuncbranchhints| mathdef:: \xref{appendix/custom}{binary-branchhintssec}{\B{funcbranchhints}}
 .. |Bbranchhint| mathdef:: \xref{appendix/custom}{binary-branchhintsec}{\B{branchhint}}
 .. |Bbranchhintkind| mathdef:: \xref{appendix/custom}{binary-branchhintsec}{\B{branchhintkind}}


### PR DESCRIPTION
The overall section structure definition wasm missing.

Fixes https://github.com/WebAssembly/branch-hinting/issues/11