### PR TITLE
branch hinting: reword the byte offset description

### DIFF
--- a/document/metadata/code/binary.rst
+++ b/document/metadata/code/binary.rst
@@ -32,7 +32,7 @@ section of format *T*.
    \end{array}
 .. index:: ! code metadata section
 
-Where :math:`\X{off}` is the byte offset of the annotation starting from the beginning of the function body, and :math:`\X{data}` is a further payload, whose content depends on the format :math:`T`.
+Where :math:`\X{off}` is the byte offset of the attached instruction, relative to the beginning of the |Bfunc| declaration, and :math:`\X{data}` is a further payload, whose content depends on the format :math:`T`.
 
 |Bcodemetadatafunc| entries must appear in order of increasing :math:`x`, and duplicate id values are not allowed. |Bcodemetadata| entries must appear in order of increasing :math:`\X{off}`, and duplicate offset values are not allowed.
 

--- a/proposals/branch-hinting/Overview.md
+++ b/proposals/branch-hinting/Overview.md
@@ -100,7 +100,7 @@ and a function index can appear at most once.
 
 Each *branch hint* structure consists of
 
-* the |U32| byte offset of the hinted instruction from the beginning of the function body,
+* the |U32| byte offset of the hinted instruction, relative to the beginning of the function locals declaration,
 * A |U32| with value `1`,
 * a |U32| indicating the meaning of the hint:
 


### PR DESCRIPTION
"function body" is unclear, and actually at odds with the definition in the core spec. The byte offset is relative to the start of the locals vector

see https://github.com/WebAssembly/branch-hinting/issues/25