### PR TITLE
Clarify the meaning of branch hints

### DIFF
--- a/document/metadata/code/binary.rst
+++ b/document/metadata/code/binary.rst
@@ -45,7 +45,7 @@ A Branch Hint is a code metadata item with format *branch_hint*.
 
 It can only be attached to |BRIF| and |IF| instructions.
 
-Its payload indicates whether the branch is likely or unlikely to be taken.
+Its payload indicates whether the branch's condition is likely or unlikely to be true.
 
 All branch hints for a module are contained in a single code metadata section
 with name *'metadata.code.branch_hint'*.
@@ -64,6 +64,6 @@ with name *'metadata.code.branch_hint'*.
    \end{array}
 .. index:: ! branch hint section
 
-A value of |Blikely| means that the branch is likely to be taken, while a
+A value of |Blikely| means that the branch's condition is likely to be true, while a
 value of |Bunlikely| means the opposite. A branch with no hints is considered
-equally likely to be taken or not.
+equally likely to have its condition be true or not.

--- a/proposals/branch-hinting/Overview.md
+++ b/proposals/branch-hinting/Overview.md
@@ -86,7 +86,7 @@ https://github.com/WebAssembly/meetings/blob/main/main/2021/CG-11-09.md
 The *branch hint section* is a **custom section** whose name string is `metadata.code.branch_hint`.
 The branch hints section should appear only once in a module, and only before the code section.
 
-The purpose of this section is to aid the compilation of conditional branch instructions, by providing a hint that a branch is very likely (or unlikely) to be taken.
+The purpose of this section is to aid the compilation of conditional branch instructions, by providing a hint that a branch's condition is very likely (or unlikely) to be true.
 
 The section contains a vector of *function branch hints* each representing the branch hints for a single function.
 
@@ -104,10 +104,10 @@ Each *branch hint* structure consists of
 * A |U32| with value `1`,
 * a |U32| indicating the meaning of the hint:
 
-| value | meaning           |
-|-------|-------------------|
-| 0     | likely not taken  |
-| 1     | likely  taken     |
+| value | meaning                   |
+|-------|---------------------------|
+| 0     | condition is likely false |
+| 1     | condition is likely true  |
 
 Elements of the vector of *branch hint* must appear in increasing byte offset order,
 and a byte offset can appear at most once. A |BRIF| or |IF| instruction must be present


### PR DESCRIPTION
"Branch taken" is ambiguous for IF . Clarify the hint refers to the condition.

Fixes #35