### PR TITLE
branch hinting: clarify section order

### DIFF
--- a/document/metadata/code/binary.rst
+++ b/document/metadata/code/binary.rst
@@ -34,7 +34,11 @@ section of format *T*.
 
 Where :math:`\X{off}` is the byte offset of the attached instruction, relative to the beginning of the |Bfunc| declaration, and :math:`\X{data}` is a further payload, whose content depends on the format :math:`T`.
 
-|Bcodemetadatafunc| entries must appear in order of increasing :math:`x`, and duplicate id values are not allowed. |Bcodemetadata| entries must appear in order of increasing :math:`\X{off}`, and duplicate offset values are not allowed.
+At most one |Bcodemetadatasec| can be present in a module for a given format *T*, and it must appear before the |Bcodesec|.
+
+|Bcodemetadatafunc| entries must appear in order of increasing :math:`x`, and duplicate id values are not allowed.
+
+|Bcodemetadata| entries must appear in order of increasing :math:`\X{off}`, and duplicate offset values are not allowed.
 
 .. _binary-branchhints:
 


### PR DESCRIPTION
As pointed out in https://github.com/llvm/llvm-project/pull/146230#discussion_r2177916148 , the spec text missed the requirement that the code metadata sections must appear before the code section